### PR TITLE
Some of the tests when migrated to Python 3 are failing

### DIFF
--- a/atest/run.py
+++ b/atest/run.py
@@ -61,17 +61,15 @@ for entry in libraries:
         args.extend(['--include', 'kwargs'])
     else:
         args.extend(['--exclude', 'kwargs'])
-    args.extend(['--loglevel','DEBUG'])
+    args.extend(['--loglevel', 'DEBUG'])
     args.extend([join(BASE, 'tests')])
-    print 'Running tests with command:\n%s' % ' '.join(args)
+    print("".join('Running tests with command:\n{0}'.format(' '.join(args))))
     subprocess.call(args)
 
-    print
-    statuschecker.process_output(OUTPUT)
-    
+    print(statuschecker.process_output(OUTPUT))
 servercontroller.stop(8270, "/Static")
 rc = robot.rebot(*outputs, outputdir=RESULTS)
 if rc == 0:
-    print 'All tests passed'
+    print('All tests passed')
 else:
-    print '%d test%s failed' % (rc, 's' if rc != 1 else '')
+    print('{0} test{1} failed'.format(rc, 's' if rc != 1 else ''))

--- a/atest/servercontroller.py
+++ b/atest/servercontroller.py
@@ -18,7 +18,7 @@ Note: Starting from CLI leaves the terminal in a messed up state.
 """
 
 from __future__ import with_statement
-import xmlrpclib
+from xmlrpc import client
 import time
 import subprocess
 import socket
@@ -82,10 +82,11 @@ def test(port, path, attempts=1):
         if i > 0:
             time.sleep(1)
         try:
-            ret = xmlrpclib.ServerProxy(url).run_keyword('get_server_language', [])
+            ret = client.ServerProxy(url).run_keyword('get_server_language', [])
         except socket.error as serr:
+            errmsg = serr.errno
             pass
-        except xmlrpclib.Error as err:
+        except client.Fault as err:
             errmsg = err.faultString
             break
         else:
@@ -97,7 +98,7 @@ def test(port, path, attempts=1):
 
 def stop(port=8270, path="/"):
     if test(port, path):
-        server = xmlrpclib.ServerProxy('http://localhost:%s%s' % (port, path))
+        server = client.ServerProxy('http://localhost:{0}{1}'.format(port, path))
         server.stop_remote_server()
         print("Remote server on port {0} path {1} stopped".format(port, path))
 

--- a/atest/servercontroller.py
+++ b/atest/servercontroller.py
@@ -37,7 +37,7 @@ def start(libraries=
         'org.robotframework.examplelib.Static:/Static' ):
     if not os.path.exists(os.path.join(BASE, 'libs', 'target', 'examplelib-jar-with-dependencies.jar')):
         cmd = 'mvn -f "%s" clean package' % os.path.join(BASE, 'libs', 'pom.xml')
-        print 'Building the test libraries with command:\n%s' % cmd
+        print('Building the test libraries with command:\n{0}'.format(cmd))
         subprocess.call(cmd, shell=True)
     files = glob.glob(os.path.join(dirname(BASE), 'target') + os.sep + '*jar-with-dependencies.jar')
     if not files:
@@ -45,7 +45,7 @@ def start(libraries=
     rs_path = os.path.join(dirname(BASE), 'target', files[0])
     tl_path = os.path.join(BASE, 'libs', 'target', 'examplelib-jar-with-dependencies.jar')
     os.environ['CLASSPATH'] = rs_path + os.pathsep + tl_path
-    print 'CLASSPATH: %s' % os.environ['CLASSPATH']
+    print('CLASSPATH: {0}'.format(os.environ['CLASSPATH']))
     results = _get_result_directory()
     port = "8270"
     args = ['java', 'org.robotframework.remoteserver.RemoteServer', '--port', port]
@@ -53,7 +53,7 @@ def start(libraries=
     paths = [x.partition(':')[2] for x in libraries]
     for lib in libraries:
         args.extend(['--library', lib])
-        print 'adding library %s on path %s' % (lib.split(':')[0], lib.split(':')[1])
+        print('adding library {0} on path {1}'.format(lib.split(':')[0], lib.split(':')[1]))
     with open(join(results, 'server.txt'), 'w') as output:
         server = subprocess.Popen(args,
                                   stdout=output, stderr=subprocess.STDOUT,
@@ -83,15 +83,15 @@ def test(port, path, attempts=1):
             time.sleep(1)
         try:
             ret = xmlrpclib.ServerProxy(url).run_keyword('get_server_language', [])
-        except socket.error, (errno, errmsg):
+        except socket.error as serr:
             pass
-        except xmlrpclib.Error, err:
+        except xmlrpclib.Error as err:
             errmsg = err.faultString
             break
         else:
-            print "Remote server running on port %s, path %s" % (port, path)
+            print("Remote server running on port {0}, path {1}".format(port, path))
             return True
-    print "Failed to connect to remote server on port %s path %s: %s" % (port, path, errmsg)
+    print("Failed to connect to remote server on port {0} path {1}: {2}".format(port, path, errmsg))
     return False
 
 
@@ -99,7 +99,7 @@ def stop(port=8270, path="/"):
     if test(port, path):
         server = xmlrpclib.ServerProxy('http://localhost:%s%s' % (port, path))
         server.stop_remote_server()
-        print "Remote server on port %s path %s stopped" % (port, path)
+        print("Remote server on port {0} path {1} stopped".format(port, path))
 
 
 if __name__ == '__main__':

--- a/atest/statuschecker.py
+++ b/atest/statuschecker.py
@@ -177,14 +177,14 @@ if __name__=='__main__':
     import os
 
     if not 2 <= len(sys.argv) <= 3 or '--help' in sys.argv:
-        print __doc__
+        print(__doc__)
         sys.exit(1)
     infile = sys.argv[1]
     outfile = sys.argv[2] if len(sys.argv) == 3 else None
-    print  "Checking %s" % os.path.abspath(infile)
+    print("Checking {0}".format(os.path.abspath(infile)))
     rc = process_output(infile, outfile)
     if outfile:
-        print "Output: %s" % os.path.abspath(outfile)
+        print("Output: {0}".format(os.path.abspath(outfile)))
     if rc > 255:
         rc = 255
     sys.exit(rc)

--- a/atest/tests/ProxyableRemote.py
+++ b/atest/tests/ProxyableRemote.py
@@ -1,6 +1,7 @@
+'''d'''
+from xmlrpc import client
+from http import client as httpclient
 from robot.libraries.Remote import Remote, XmlRpcRemoteClient
-import xmlrpclib
-import httplib
 
 
 class ProxyableRemote(Remote):
@@ -19,10 +20,10 @@ class ProxyableXmlRpcRemoteClient(XmlRpcRemoteClient):
         if proxy is not None:
             tp = ProxiedTransport()
             tp.set_proxy(proxy)
-        self._server = xmlrpclib.ServerProxy(uri, transport=tp, encoding='UTF-8')
+        self._server = client.ServerProxy(uri, transport=tp, encoding='UTF-8')
 
 
-class ProxiedTransport(xmlrpclib.Transport):
+class ProxiedTransport(server.Transport):
 
     def set_proxy(self, proxy):
         self.proxy = proxy
@@ -30,9 +31,9 @@ class ProxiedTransport(xmlrpclib.Transport):
     def make_connection(self, host):
         self.realhost = host
         if self.proxy is None:
-            h = httplib.HTTPConnection()
+            h = httpclient.HTTPConnection()
         else:
-            h = httplib.HTTPConnection(self.proxy)
+            h = httpclient.HTTPConnection(self.proxy)
         self._connection = host, h
         return h
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.8.1</version>
@@ -116,7 +116,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Return Control Char:
Error: 

> Fails if the given objects are unequal.
> Argument types are:
> <class 'bytes'>
> <type 'unicode'> 
>  **FAIL  (bytes) !=  (string)** 
>  

 Return Date
Error:
 

> ${actual} = Wed Dec 31 16:00:00 PST 1969 
> 
> Argument types are:
> **_<type 'unicode'>_**
> **_<type 'unicode'>_** 
> 
> **FAIL Wed Dec 31 16:00:00 PST 1969 != Wed Dec 31 18:00:00 CST 1969** 
