### PR TITLE
Fix casting exception with libraries using javalibcore 2

### DIFF
--- a/src/main/java/org/robotframework/remoteserver/library/DynamicApiRemoteLibrary.java
+++ b/src/main/java/org/robotframework/remoteserver/library/DynamicApiRemoteLibrary.java
@@ -41,8 +41,7 @@ public class DynamicApiRemoteLibrary implements RemoteLibrary {
         try {
             Object names = getKeywordNames.invoke(library, new Object[] {});
             if (names instanceof List) {
-                Object[] nameArray = ((List<?>) names).toArray();
-                return Arrays.copyOf(nameArray, nameArray.length, String[].class);
+                return ((List<?>) names).toArray(new String[0]);
             } else {
                 return (String[]) names;
             }

--- a/src/main/java/org/robotframework/remoteserver/library/DynamicApiRemoteLibrary.java
+++ b/src/main/java/org/robotframework/remoteserver/library/DynamicApiRemoteLibrary.java
@@ -41,7 +41,8 @@ public class DynamicApiRemoteLibrary implements RemoteLibrary {
         try {
             Object names = getKeywordNames.invoke(library, new Object[] {});
             if (names instanceof List) {
-                return (String[]) ((List<?>) names).toArray();
+                Object[] nameArray = ((List<?>) names).toArray();
+                return Arrays.copyOf(nameArray, nameArray.length, String[].class);
             } else {
                 return (String[]) names;
             }

--- a/src/test/java/org/robotframework/remoteserver/testlibraries/DynamicUsingLists.java
+++ b/src/test/java/org/robotframework/remoteserver/testlibraries/DynamicUsingLists.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public class DynamicUsingLists {
     
-    public List<String> getKeywordNames() {
-        return Arrays.asList(new String[] {"go"});
+    public List<Object> getKeywordNames() {
+        return Arrays.asList(new Object[] {"go"});
     }
 
     public Object runKeyword(String name, List<?> arguments) {


### PR DESCRIPTION
Remote library import fails with message `<Fault 0: 'Failed to invoke method get_keyword_names in class org.robotframework.remoteserver.servlet.ServerMethods: java.lang.RuntimeException: [Ljava.lang.Object; cannot be cast to [Ljava.lang.String;'>` when the library is based on [javalibcore 2](https://github.com/robotframework/JavalibCore/wiki/Javalib-core-2.x.x). The list returned by getKeywordNames has Object as element type and when trying to cast the return value to string array with `(String[]) ((List<?>) names).toArray()` a ClassCastException is thrown. This can be fixed by using `Arrays.copyOf` for the conversion since it also handles Object arrays.

I couldn't find out the reason why getKeywordArguments still works, it seems to have undergone the exact same changes as getKeywordNames but the element type for returned list is String and casting it to a string array still works.

Javalibcore commit where the return types have been modified:
[getKeywordNames](https://github.com/robotframework/JavalibCore/commit/96d90c5828eaa9579be86b9b975ff86f767546d3#diff-3ef59d502bd86beb2570289311d7c267L51)
[getKeywordArguments](https://github.com/robotframework/JavalibCore/commit/96d90c5828eaa9579be86b9b975ff86f767546d3#diff-46f07295a33ad1da0a9021730a5f53f2L109)