### PR TITLE
Fix exceptions to do with init and intro keywords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>11.0.3</version>
+			<version>11.0.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/org/robotframework/remoteserver/servlet/ServerMethods.java
+++ b/src/main/java/org/robotframework/remoteserver/servlet/ServerMethods.java
@@ -52,8 +52,10 @@ public class ServerMethods {
     public List<String> get_keyword_names() {
         try {
             List<String> names = servlet.getLibrary().getKeywordNames();
-            if (names == null || names.size() == 0)
+            if (names == null || names.isEmpty())
                 throw new RuntimeException("No keywords found in the test library");
+            if (!names.contains("__intro__")) names.add("__intro__");
+            if (!names.contains("__init__")) names.add("__init__");
             if (!names.contains("stop_remote_server")) names.add("stop_remote_server");
             return names;
         } catch (Throwable e) {
@@ -157,12 +159,12 @@ public class ServerMethods {
      * @return A string array of argument specifications for the given keyword.
      */
     public List<String> get_keyword_arguments(String keyword) {
-        if (keyword.equalsIgnoreCase("stop_remote_server")) {
-            return Arrays.asList();
-        }
+        if (keyword.equalsIgnoreCase("stop_remote_server"))  return Collections.emptyList();
+        if (keyword.equalsIgnoreCase("__intro__"))  return Collections.emptyList();
+        if (keyword.equalsIgnoreCase("__init__"))  return Collections.emptyList();
         try {
             List<String> args = servlet.getLibrary().getKeywordArguments(keyword);
-            return args == null ? Arrays.<String>asList() : args;
+            return args == null ? Collections.emptyList() : args;
         } catch (Throwable e) {
             log.warn("", e);
             throw new RuntimeException(e);
@@ -177,6 +179,9 @@ public class ServerMethods {
      * @return A documentation string for the given keyword.
      */
     public String get_keyword_documentation(String keyword) {
+        if (keyword.equalsIgnoreCase("__init__")) {
+            return "";
+        }
         if (keyword.equalsIgnoreCase("stop_remote_server")) {
             return "Stops the remote server.\n\nThe server may be configured so that users cannot stop it.";
         }


### PR DESCRIPTION
This commit works to address issues with missing keyword exceptions for univeral calls such as __init__ and __info__. Note, without this change (or something else that  may be related),  it is not possible to generate remote library documentation.